### PR TITLE
Move config secrets to .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+JWT_SECRET=supersecret
+MONGO_URI=mongodb://localhost/conduit

--- a/config/app.js
+++ b/config/app.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const path = require('path');
 const morgan = require('morgan');

--- a/config/index.js
+++ b/config/index.js
@@ -1,3 +1,4 @@
 module.exports = {
-  secret: process.env.NODE_ENV === 'production' ? process.env.SECRET : 'secret'
+  secret: process.env.JWT_SECRET,
+  mongoURI: process.env.MONGO_URI
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "request": "2.69.0",
     "slug": "0.9.1",
     "underscore": "1.8.3",
-    "helmet": "^7.0.0"
+    "helmet": "^7.0.0",
+    "dotenv": "^16.3.1"
   },
   "devDependencies": {
     "newman": "^6.0.0",

--- a/server.js
+++ b/server.js
@@ -1,12 +1,11 @@
 const mongoose = require('mongoose');
 const app = require('./config/app');
+const config = require('./config');
 
 const isProduction = process.env.NODE_ENV === 'production';
 
-if (isProduction) {
-  mongoose.connect(process.env.MONGODB_URI);
-} else {
-  mongoose.connect('mongodb://localhost/conduit');
+mongoose.connect(config.mongoURI || 'mongodb://localhost/conduit');
+if (!isProduction) {
   mongoose.set('debug', true);
 }
 


### PR DESCRIPTION
## Summary
- load dotenv in app setup
- read JWT secret and Mongo URI from environment variables
- connect to MongoDB using config values
- include dotenv as dependency
- add example `.env`

## Testing
- `npm test` *(fails: newman not found)*

------
https://chatgpt.com/codex/tasks/task_e_685da0d74e4883218e024f70391c869a