### PR TITLE
Fix mongoose-unique-validator peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "method-override": "2.3.5",
     "methods": "1.1.2",
     "mongoose": "^7.5.0",
-    "mongoose-unique-validator": "1.0.2",
+    "mongoose-unique-validator": "^3.1.0",
     "morgan": "1.7.0",
     "passport": "^0.6.0",
     "passport-local": "1.0.0",


### PR DESCRIPTION
## Summary
- bump `mongoose-unique-validator` to `^3.1.0`

## Testing
- `npm install` *(fails: 403 Forbidden due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_685daabe406883219f6d6d6d809d3031