### PR TITLE
Fix mongoose unique validator version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "method-override": "2.3.5",
     "methods": "1.1.2",
     "mongoose": "^7.5.0",
-    "mongoose-unique-validator": "^3.1.1",
+    "mongoose-unique-validator": "^2.0.3",
     "morgan": "1.7.0",
     "passport": "^0.6.0",
     "passport-local": "1.0.0",


### PR DESCRIPTION
## Summary
- use stable `mongoose-unique-validator@^2.0.3`
