### PR TITLE
Add unauthorized comment post test

### DIFF
--- a/tests/api-tests.postman.json
+++ b/tests/api-tests.postman.json
@@ -2438,6 +2438,42 @@
           "response": []
         },
         {
+          "name": "Create Comment for Article - No Token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "tests['Status code is 401'] = responseCode.code === 401;"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "url": "{{apiUrl}}/articles/{{slug}}/comments",
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "description": ""
+              },
+              {
+                "key": "X-Requested-With",
+                "value": "XMLHttpRequest",
+                "description": ""
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"comment\":{\"body\":\"Thank you so much!\"}}"
+            },
+            "description": ""
+          },
+          "response": []
+        },
+        {
           "name": "Delete Comment - No Token",
           "event": [
             {


### PR DESCRIPTION
## Summary
- extend Postman tests with a case for posting a comment without authorization

## Testing
- `npm test` *(fails: `newman` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df9a855148321aa4698839ae803d1